### PR TITLE
start.sh: create folder buildenv when not there

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -28,5 +28,8 @@ if [ -d "${ssh_dir}" ]; then
   mounts+=("--mount" "type=bind,source=${ssh_dir},target=${home_dir}/.ssh")
 fi
 
+# provide (empty) folder buildenv
+mkdir -p buildenv
+
 # Start the containerized environment
 docker container run -it --init --rm --name "${IMAGE}" "${mounts[@]}" "${MAINTAINER}/${IMAGE}:${VERSION}"


### PR DESCRIPTION
if folder buildenv is not around the script will stop to work.
(yocto build for target x86/64 qemu tested positive)